### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/IDNA/Punycode.pm
+++ b/lib/IDNA/Punycode.pm
@@ -1,6 +1,5 @@
-
 use v6;
-module IDNA::Punycode;
+unit module IDNA::Punycode;
 
 our $DEBUG = 0;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
